### PR TITLE
Skip loop in case of null dictionary

### DIFF
--- a/target_parquet/helpers.py
+++ b/target_parquet/helpers.py
@@ -78,12 +78,13 @@ def flatten_schema(dictionary, parent_key="", sep="__"):
         ]
     """
     items = []
-    for k, v in dictionary.items():
-        new_key = parent_key + sep + k if parent_key else k
-        if "type" not in v:
-            LOGGER.warning(f"SCHEMA with limitted support on field {k}: {v}")
-        if "object" in v.get("type", []):
-            items.extend(flatten_schema(v.get("properties"), new_key, sep=sep))
-        else:
-            items.append(new_key)
+    if dictionary:
+        for k, v in dictionary.items():
+            new_key = parent_key + sep + k if parent_key else k
+            if "type" not in v:
+                LOGGER.warning(f"SCHEMA with limitted support on field {k}: {v}")
+            if "object" in v.get("type", []):
+                items.extend(flatten_schema(v.get("properties"), new_key, sep=sep))
+            else:
+                items.append(new_key)
     return items


### PR DESCRIPTION
Hi there!

I was getting the following error when trying to pull data from a github repository using the `tap-github` with `target-parquet` in Meltano:

```
File "/var/opt/meltano/.meltano/loaders/target-parquet/venv/lib/python3.9/site-packages/target_parquet/helpers.py", line 81, in flatten_schema
    for k, v in dictionary.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

I add a simple check if the nested dictionary is empty before the loop to avoid the exception.