### PR TITLE
Upgrade pyarrow to 10.0.1 and allow switchable parquet versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ ENV/
 
 # VS Code project settings
 .vscode/
+
+.idea/

--- a/config.sample.json
+++ b/config.sample.json
@@ -4,5 +4,5 @@
   "destination_path": "/path/to/the/output/directory/",
   "compression_method": "snappy",
   "streams_in_separate_folder": false,
-  "parquet_version": 2.4
+  "parquet_version": "2.4"
 }

--- a/config.sample.json
+++ b/config.sample.json
@@ -3,5 +3,6 @@
   "logging_level": "INFO",
   "destination_path": "/path/to/the/output/directory/",
   "compression_method": "snappy",
-  "streams_in_separate_folder": false
+  "streams_in_separate_folder": false,
+  "parquet_version": 2.4
 }

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="target-parquet",
-    version="0.2.5",
+    version="0.3.0",
     description="Singer.io target for writing into parquet files",
     author="Rafael 'Auyer' Passos",
     url="https://singer.io",
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         "jsonschema==2.6.0",
         "singer-python==5.12.2",
-        "pyarrow==8.0.0",
+        "pyarrow==10.0.1",
         "psutil==5.9.1",
     ],
     extras_require={"dev": ["pytest==7.1.2", "pandas==1.4.2"]},

--- a/target_parquet/__init__.py
+++ b/target_parquet/__init__.py
@@ -276,7 +276,7 @@ def main():
         input_messages,
         destination_path=config.get("destination_path", "."),
         compression_method=config.get("compression_method", None),
-        parquet_version=config.get("parquet_version", 1.0),
+        parquet_version=config.get("parquet_version", "1.0"),
         streams_in_separate_folder=config.get("streams_in_separate_folder", False),
         file_size=int(config.get("file_size", -1)),
     )

--- a/target_parquet/__init__.py
+++ b/target_parquet/__init__.py
@@ -70,6 +70,7 @@ class MemoryReporter(threading.Thread):
 def persist_messages(
     messages,
     destination_path,
+    parquet_version,
     compression_method=None,
     streams_in_separate_folder=False,
     file_size=-1,
@@ -169,7 +170,7 @@ def persist_messages(
         filepath = os.path.expanduser(os.path.join(destination_path, filename))
         with open(filepath, "wb") as f:
             ParquetWriter(
-                f, dataframe.schema, compression=compression_method
+                f, dataframe.schema, compression=compression_method, version=parquet_version
             ).write_table(dataframe)
         ## explicit memory management. This can be usefull when working on very large data groups
         del dataframe
@@ -273,10 +274,11 @@ def main():
         MemoryReporter().start()
     state = persist_messages(
         input_messages,
-        config.get("destination_path", "."),
-        config.get("compression_method", None),
-        config.get("streams_in_separate_folder", False),
-        int(config.get("file_size", -1)),
+        destination_path=config.get("destination_path", "."),
+        compression_method=config.get("compression_method", None),
+        parquet_version=config.get("parquet_version", 1.0),
+        streams_in_separate_folder=config.get("streams_in_separate_folder", False),
+        file_size=int(config.get("file_size", -1)),
     )
 
     emit_state(state)


### PR DESCRIPTION
as of now, TRINO 405 is starting to require/support newer parquet file versions than 1.0 .. and the spec has now getting to 2.6 as of todays date (and the default in pyarrow 10.0.1) 

This PR attempts to add the ability for you as an end user to select the desired parquet output version.. I need to test this further.. in order to ensure I can get proper `TIMESTAMP` support from this target as per https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp .. using meltano I guess we'd need to use `timeType` or `datetimeType` .. unclear yet